### PR TITLE
Don't indefinitely persist file hashes

### DIFF
--- a/app/src/event_converter.c
+++ b/app/src/event_converter.c
@@ -149,10 +149,10 @@ convert_mouse_buttons(uint32_t state) {
     if (state & SDL_BUTTON_MMASK) {
         buttons |= AMOTION_EVENT_BUTTON_TERTIARY;
     }
-    if (state & SDL_BUTTON_X1) {
+    if (state & SDL_BUTTON_X1MASK) {
         buttons |= AMOTION_EVENT_BUTTON_BACK;
     }
-    if (state & SDL_BUTTON_X2) {
+    if (state & SDL_BUTTON_X2MASK) {
         buttons |= AMOTION_EVENT_BUTTON_FORWARD;
     }
     return buttons;


### PR DESCRIPTION
The conversion from SDL mouse state to Android mouse state used wrong
constants as mask.

Fixes <https://github.com/Genymobile/scrcpy/issues/635>